### PR TITLE
Create DateTime abstract class 

### DIFF
--- a/examples/send_attachments.cpp
+++ b/examples/send_attachments.cpp
@@ -3,6 +3,7 @@
 */
 
 #include "attachment/attachment.hpp"
+#include "date_time/date_time_now.hpp"
 #include "email/email.hpp"
 
 using namespace smtp;
@@ -16,7 +17,7 @@ int main(void) {
   e.setFrom("test_from@gmail.com");
   e.setSubject("Testing sending attachments");
   e.setBody("Hey listen friend here are some attachments for you to play with!");
-  e.setDate("01/08/1003 01:05:24 +1100");
+  e.setDate(DateTimeNow());
 
   Attachment a{"mountain-beach.jpg"};
   Attachment a2{"mountain-beach2.jpg"};

--- a/src/date_time/date_time.hpp
+++ b/src/date_time/date_time.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+namespace smtp {
+
+class DateTime {
+public:
+  virtual ~DateTime() = default;
+  virtual std::string getTimestamp() const = 0;
+};
+
+} // namespace smtp

--- a/src/date_time/date_time_now.cpp
+++ b/src/date_time/date_time_now.cpp
@@ -1,0 +1,19 @@
+#include "date_time_now.hpp"
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+
+namespace smtp {
+
+std::string DateTimeNow::getTimestamp() const {
+  auto cur_time = std::chrono::system_clock::now();
+  const std::time_t &time_t_obj = std::chrono::system_clock::to_time_t(cur_time);
+
+  std::stringstream ss;
+  ss << std::put_time(std::localtime(&time_t_obj), "%d/%m/%Y %I:%M:%S +1100");
+
+  return ss.str();
+}
+
+} // namespace smtp

--- a/src/date_time/date_time_now.hpp
+++ b/src/date_time/date_time_now.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "date_time.hpp"
+
+namespace smtp {
+
+class DateTimeNow : public DateTime {
+public:
+  std::string getTimestamp() const override;
+};
+
+} // namespace smtp

--- a/src/email/email.cpp
+++ b/src/email/email.cpp
@@ -21,11 +21,10 @@ struct UploadStatus {
 };
 
 static size_t payloadCallback(void *ptr, size_t size, size_t nmemb, void *userp);
-static std::string getCurrentDateTime();
 
 Email::Email(const EmailParams &params)
     : m_smtp_user{params.user}, m_smtp_password{params.password},
-      m_smtp_host{params.hostname}, m_date{getCurrentDateTime()} {}
+      m_smtp_host{params.hostname}, m_date{DateTimeNow().getTimestamp()} {}
 
 void Email::addAttachment(const Attachment &attachment) { m_attachments.push_back(attachment); }
 
@@ -33,20 +32,11 @@ void Email::removeAttachment(std::string_view file_path) {
   const auto &checkFilePath = [&file_path](const Attachment &attachment) {
     return attachment.getFilePath() == file_path;
   };
+
   if (const auto &it = std::find_if(m_attachments.begin(), m_attachments.end(), checkFilePath);
       it != m_attachments.end()) {
     m_attachments.erase(it);
   }
-}
-
-static std::string getCurrentDateTime() {
-  auto cur_time = std::chrono::system_clock::now();
-  const std::time_t &time_t_obj = std::chrono::system_clock::to_time_t(cur_time);
-
-  std::stringstream ss;
-  ss << std::put_time(std::localtime(&time_t_obj), "%d/%m/%Y %I:%M:%S +1100");
-
-  return ss.str();
 }
 
 std::vector<std::string> Email::build() const {
@@ -195,7 +185,7 @@ void Email::clear() {
   m_from.clear();
   m_cc.clear();
   m_subject.clear();
-  m_date = getCurrentDateTime();
+  m_date = DateTimeNow().getTimestamp();
   m_body.clear();
 
   m_attachments.clear();

--- a/src/email/email.hpp
+++ b/src/email/email.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "attachment/attachment.hpp"
+#include "date_time/date_time_now.hpp"
 #include "utils/secure_strings.hpp"
 
 namespace smtp {
@@ -24,11 +25,7 @@ public:
   void setCc(std::string_view cc) { m_cc = cc; }
   void setSubject(std::string_view subject) { m_subject = subject; }
   void setBody(std::string_view body) { m_body = body; }
-
-  // Optional: If the date is not set using this method then the current datetime will be used by
-  // default. If you choose to use this method then the format of the date is dd/mm/yyyy HH:MM:SS +z
-  // e.g 25/07/2023 07:21:05 +1100
-  void setDate(std::string_view date) { m_date = date; }
+  void setDate(const DateTime &dt) { m_date = dt.getTimestamp(); }
 
   void addAttachment(const Attachment &attachment);
   void removeAttachment(std::string_view file_path);

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,6 +8,7 @@ smtp_srcs = [
     'mime/mime.cpp',
     'utils/base64/base64.cpp',
     'attachment/attachment.cpp',
+    'date_time/date_time_now.cpp',
 ]
 
 # incdir comes from the meson build in the ./ directory

--- a/tests/email/email_tests.cpp
+++ b/tests/email/email_tests.cpp
@@ -6,8 +6,14 @@
 
 #include "doctest/doctest.h"
 
+#include "date_time/date_time_now.hpp"
 #include "email/email.hpp"
 #include "mime/mime.hpp"
+
+class DateTimeStatic : public smtp::DateTime {
+public:
+  std::string getTimestamp() const override { return "25/07/2023 07:21:05 +1100"; }
+};
 
 TEST_SUITE("Email tests") {
   TEST_CASE("Basic email test") {
@@ -18,7 +24,7 @@ TEST_SUITE("Email tests") {
     email.setFrom("tully@gmail.com");
     email.setSubject("PWC pay rise");
     email.setCc("All the bosses at PWC");
-    email.setDate("25/07/2023 07:21:05 +1100");
+    email.setDate(DateTimeStatic());
     email.setBody("Hey mate, I have been working here for 5 years now, I think "
                   "its time for a pay rise.");
 
@@ -56,7 +62,7 @@ TEST_SUITE("Email tests") {
     email.setTo("bigboss@gmail.com");
     email.setFrom("tully@gmail.com");
     email.setSubject("PWC pay rise");
-    email.setDate("25/07/2023 07:21:05 +1100");
+    email.setDate(DateTimeStatic());
     email.setCc("All the bosses at PWC");
     email.setBody("Hey mate, I have been working here for 5 years now, I think "
                   "its time for a pay rise.");
@@ -110,7 +116,7 @@ TEST_SUITE("Email tests") {
     email.setTo("bigboss@gmail.com");
     email.setFrom("tully@gmail.com");
     email.setSubject("PWC pay rise");
-    email.setDate("25/07/2023 07:21:05 +1100");
+    email.setDate(DateTimeStatic());
     email.setCc("All the bosses at PWC");
     email.setBody("Hey mate, I have been working here for 5 years now, I think "
                   "its time for a pay rise.");
@@ -173,7 +179,7 @@ TEST_SUITE("Email tests") {
     email.setFrom("tully@gmail.com");
     email.setSubject("PWC pay rise");
     email.setCc("All the bosses at PWC");
-    email.setDate("25/07/2023 07:21:05 +1100");
+    email.setDate(DateTimeStatic());
     email.setBody("Hey mate, I have been working here for 5 years now, I think "
                   "its time for a pay rise.");
 
@@ -183,7 +189,7 @@ TEST_SUITE("Email tests") {
     email.addAttachment(attachment_one);
 
     email.clear();
-    email.setDate("25/07/2023 07:21:05 +1100");
+    email.setDate(DateTimeStatic());
 
     const std::string &expected = "To: \r\n"
                                   "From: \r\n"


### PR DESCRIPTION
# Context:

Writing unit tests for the Email class is hard since the timestamp used in the Email will be different from the expected timestamp. 

Create an abstract class to allow us to mock the date and time in a clear and maintainable way.