### PR TITLE
remove setters from email class

### DIFF
--- a/examples/send_attachments.cpp
+++ b/examples/send_attachments.cpp
@@ -18,7 +18,7 @@ int main(void) {
       "",                                                                  // cc
       "Testing sending attachments",                                       // subject
       "Hey listen friend here are some attachments for you to play with!", // body
-  };                                                                       // optional date
+  };
   Email e{params};
 
   Attachment a{"mountain-beach.jpg"};

--- a/examples/send_attachments.cpp
+++ b/examples/send_attachments.cpp
@@ -9,15 +9,17 @@
 using namespace smtp;
 
 int main(void) {
-  EmailParams params{"test_username", "test_password",
-                     "smtps://email-smtp.ap-southeast-2.amazonaws.com:465"};
+  EmailParams params{
+      "test_username",                                                     // smtp username
+      "test_password",                                                     // smtp password
+      "smtps://email-smtp.ap-southeast-2.amazonaws.com:465",               // smtp server
+      "test_to@gmail.com",                                                 // to
+      "test_from@gmail.com",                                               // from
+      "",                                                                  // cc
+      "Testing sending attachments",                                       // subject
+      "Hey listen friend here are some attachments for you to play with!", // body
+  };                                                                       // optional date
   Email e{params};
-
-  e.setTo("test_to@gmail.com");
-  e.setFrom("test_from@gmail.com");
-  e.setSubject("Testing sending attachments");
-  e.setBody("Hey listen friend here are some attachments for you to play with!");
-  e.setDate(DateTimeNow());
 
   Attachment a{"mountain-beach.jpg"};
   Attachment a2{"mountain-beach2.jpg"};

--- a/src/email/email.cpp
+++ b/src/email/email.cpp
@@ -1,12 +1,5 @@
 #include <algorithm>
-#include <chrono>
 #include <cstdint>
-#include <cstring>
-#include <ctime>
-#include <iomanip>
-#include <iostream>
-#include <memory>
-#include <sstream>
 #include <string>
 
 #include "email/email.hpp"

--- a/src/email/email.hpp
+++ b/src/email/email.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -14,18 +15,18 @@ struct EmailParams {
   std::string_view user;
   std::string_view password;
   std::string_view hostname;
+
+  std::string_view to;
+  std::string_view from;
+  std::string_view cc;
+  std::string_view subject;
+  std::string_view body;
+  const DateTime *datetime = nullptr;
 };
 
 class Email {
 public:
   explicit Email(const EmailParams &params);
-
-  void setTo(std::string_view to) { m_to = to; }
-  void setFrom(std::string_view from) { m_from = from; }
-  void setCc(std::string_view cc) { m_cc = cc; }
-  void setSubject(std::string_view subject) { m_subject = subject; }
-  void setBody(std::string_view body) { m_body = body; }
-  void setDate(const DateTime &dt) { m_date = dt.getTimestamp(); }
 
   void addAttachment(const Attachment &attachment);
   void removeAttachment(std::string_view file_path);
@@ -44,12 +45,13 @@ private:
   std::string m_from;
   std::string m_cc;
   std::string m_subject;
-  std::string m_date;
   std::string m_body;
 
+  const DateTime *m_date = nullptr;
   std::vector<Attachment> m_attachments;
 
   std::vector<std::string> build() const;
+  std::string getDatetime() const;
 
   friend std::ostream &operator<<(std::ostream &out, const Email &email) {
     const std::vector<std::string> &email_contents = email.build();

--- a/src/email/email.hpp
+++ b/src/email/email.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/tests/email/email_tests.cpp
+++ b/tests/email/email_tests.cpp
@@ -17,16 +17,21 @@ public:
 
 TEST_SUITE("Email tests") {
   TEST_CASE("Basic email test") {
-    smtp::EmailParams params{"user", "password", "hostname"};
-    smtp::Email email(params);
+    const auto dateTimeStatic = std::make_unique<DateTimeStatic>();
+    smtp::EmailParams params{
+        "user",                  // smtp username
+        "password",              // smtp password
+        "hostname",              // smtp server
+        "bigboss@gmail.com",     // to
+        "tully@gmail.com",       // from
+        "All the bosses at PWC", // cc
+        "PWC pay rise",          // subject
+        "Hey mate, I have been working here for 5 years now, I think "
+        "its time for a pay rise.", // body
+        dateTimeStatic.get()        // optional datetime
+    };
 
-    email.setTo("bigboss@gmail.com");
-    email.setFrom("tully@gmail.com");
-    email.setSubject("PWC pay rise");
-    email.setCc("All the bosses at PWC");
-    email.setDate(DateTimeStatic());
-    email.setBody("Hey mate, I have been working here for 5 years now, I think "
-                  "its time for a pay rise.");
+    smtp::Email email(params);
 
     const std::string &expected =
         "To: bigboss@gmail.com\r\n"
@@ -56,16 +61,20 @@ TEST_SUITE("Email tests") {
   }
 
   TEST_CASE("Add attachment test") {
-    smtp::EmailParams params{"user", "password", "hostname"};
+    const auto dateTimeStatic = std::make_unique<DateTimeStatic>();
+    smtp::EmailParams params{
+        "user",                  // smtp username
+        "password",              // smtp password
+        "hostname",              // smtp server
+        "bigboss@gmail.com",     // to
+        "tully@gmail.com",       // from
+        "All the bosses at PWC", // cc
+        "PWC pay rise",          // subject
+        "Hey mate, I have been working here for 5 years now, I think "
+        "its time for a pay rise.", // body
+        dateTimeStatic.get()        // optional datetime
+    };
     smtp::Email email(params);
-
-    email.setTo("bigboss@gmail.com");
-    email.setFrom("tully@gmail.com");
-    email.setSubject("PWC pay rise");
-    email.setDate(DateTimeStatic());
-    email.setCc("All the bosses at PWC");
-    email.setBody("Hey mate, I have been working here for 5 years now, I think "
-                  "its time for a pay rise.");
 
     smtp::Attachment attachment;
     const std::string &contents = "MimeMockAttachment";
@@ -110,16 +119,20 @@ TEST_SUITE("Email tests") {
   }
 
   TEST_CASE("Remove attachment test") {
-    smtp::EmailParams params{"user", "password", "hostname"};
+    const auto dateTimeStatic = std::make_unique<DateTimeStatic>();
+    smtp::EmailParams params{
+        "user",                  // smtp username
+        "password",              // smtp password
+        "hostname",              // smtp server
+        "bigboss@gmail.com",     // to
+        "tully@gmail.com",       // from
+        "All the bosses at PWC", // cc
+        "PWC pay rise",          // subject
+        "Hey mate, I have been working here for 5 years now, I think "
+        "its time for a pay rise.", // body
+        dateTimeStatic.get()        // optional datetime
+    };
     smtp::Email email(params);
-
-    email.setTo("bigboss@gmail.com");
-    email.setFrom("tully@gmail.com");
-    email.setSubject("PWC pay rise");
-    email.setDate(DateTimeStatic());
-    email.setCc("All the bosses at PWC");
-    email.setBody("Hey mate, I have been working here for 5 years now, I think "
-                  "its time for a pay rise.");
 
     smtp::Attachment attachment_one;
     const std::string &contents_one = "MimeMockAttachment";
@@ -172,24 +185,26 @@ TEST_SUITE("Email tests") {
   }
 
   TEST_CASE("Clear test") {
-    smtp::EmailParams params{"user", "password", "hostname"};
+    const auto dateTimeStatic = std::make_unique<DateTimeStatic>();
+    smtp::EmailParams params{
+        "user",                  // smtp username
+        "password",              // smtp password
+        "hostname",              // smtp server
+        "bigboss@gmail.com",     // to
+        "tully@gmail.com",       // from
+        "All the bosses at PWC", // cc
+        "PWC pay rise",          // subject
+        "Hey mate, I have been working here for 5 years now, I think "
+        "its time for a pay rise.", // body
+        dateTimeStatic.get()        // optional datetime
+    };
     smtp::Email email(params);
-
-    email.setTo("bigboss@gmail.com");
-    email.setFrom("tully@gmail.com");
-    email.setSubject("PWC pay rise");
-    email.setCc("All the bosses at PWC");
-    email.setDate(DateTimeStatic());
-    email.setBody("Hey mate, I have been working here for 5 years now, I think "
-                  "its time for a pay rise.");
 
     smtp::Attachment attachment_one;
     const std::string &contents_one = "MimeMockAttachment";
     attachment_one.setContents(std::vector<uint8_t>(contents_one.begin(), contents_one.end()));
     email.addAttachment(attachment_one);
-
     email.clear();
-    email.setDate(DateTimeStatic());
 
     const std::string &expected = "To: \r\n"
                                   "From: \r\n"

--- a/tests/email/email_tests.cpp
+++ b/tests/email/email_tests.cpp
@@ -15,9 +15,10 @@ public:
   std::string getTimestamp() const override { return "25/07/2023 07:21:05 +1100"; }
 };
 
+const auto dateTimeStatic = std::make_unique<DateTimeStatic>();
+
 TEST_SUITE("Email tests") {
   TEST_CASE("Basic email test") {
-    const auto dateTimeStatic = std::make_unique<DateTimeStatic>();
     smtp::EmailParams params{
         "user",                  // smtp username
         "password",              // smtp password
@@ -61,7 +62,6 @@ TEST_SUITE("Email tests") {
   }
 
   TEST_CASE("Add attachment test") {
-    const auto dateTimeStatic = std::make_unique<DateTimeStatic>();
     smtp::EmailParams params{
         "user",                  // smtp username
         "password",              // smtp password
@@ -119,7 +119,6 @@ TEST_SUITE("Email tests") {
   }
 
   TEST_CASE("Remove attachment test") {
-    const auto dateTimeStatic = std::make_unique<DateTimeStatic>();
     smtp::EmailParams params{
         "user",                  // smtp username
         "password",              // smtp password
@@ -185,7 +184,6 @@ TEST_SUITE("Email tests") {
   }
 
   TEST_CASE("Clear test") {
-    const auto dateTimeStatic = std::make_unique<DateTimeStatic>();
     smtp::EmailParams params{
         "user",                  // smtp username
         "password",              // smtp password


### PR DESCRIPTION
# Context:

Remove setters and moved these fields in the `EmailParams` struct instead.

This makes initializing the Email class easier.