### PR TITLE
Fixed compile issues with secure strings

### DIFF
--- a/src/utils/secure_strings.hpp
+++ b/src/utils/secure_strings.hpp
@@ -28,7 +28,7 @@ public:
   SecureAllocator() = default;
   ~SecureAllocator() = default;
 
-  template <class U> SecureAllocator(const SecureAllocator<U> &) {}
+  template <class U> explicit SecureAllocator(const SecureAllocator<U> &) {}
 
   pointer allocate(size_type num_objects) {
     if (num_objects > (max_size() / sizeof(T)))

--- a/src/utils/secure_strings.hpp
+++ b/src/utils/secure_strings.hpp
@@ -28,7 +28,7 @@ public:
   SecureAllocator() = default;
   ~SecureAllocator() = default;
 
-  template <class U> SecureAllocator(const SecureAllocator<U> &other) {}
+  template <class U> SecureAllocator(const SecureAllocator<U> &) {}
 
   pointer allocate(size_type num_objects) {
     if (num_objects > (max_size() / sizeof(T)))
@@ -36,7 +36,7 @@ public:
     return static_cast<pointer>(new value_type[num_objects]);
   }
 
-  pointer allocate(size_type num_objects, const_void_pointer hint) { return allocate(num_objects); }
+  pointer allocate(size_type num_objects, const_void_pointer) { return allocate(num_objects); }
 
   void deallocate(pointer p, size_type num_objects) {
     std::memset(p, 0x0, num_objects);

--- a/tests/utils/secure_strings_tests.cpp
+++ b/tests/utils/secure_strings_tests.cpp
@@ -13,10 +13,6 @@ TEST_SUITE("Secure strings") {
     void *ptr = password->data();
     CHECK(std::memcmp(password->data(), expected.data(), expected.size()) == 0);
 
-    int len = static_cast<int>(expected.size());
-    char arr[len] = {0x0};
-    std::memset(arr, 0x0, len);
-
     delete password;
 
     // Ensure that each byte is different at this memory location and that the


### PR DESCRIPTION
# Description

#32 

The latest build on the [PR](https://github.com/conan-io/conan-center-index/pull/19398) to add this library as a package to conan-center failed since it couldn't be compiled by Clang. The issue was some unused variables in the `secure_strings` module.

## Dependencies
Any dependencies such as new C++ packages or existing package version updates should be listed here.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
