### PR TITLE
Clang-12 build errors

### DIFF
--- a/src/utils/secure_strings.hpp
+++ b/src/utils/secure_strings.hpp
@@ -46,6 +46,16 @@ public:
   size_type max_size() const { return std::numeric_limits<size_type>::max(); }
 };
 
+template <typename T, typename U>
+constexpr bool operator==(const SecureAllocator<T> &, const SecureAllocator<U> &) noexcept {
+  return true;
+}
+
+template <typename T, typename U>
+constexpr bool operator!=(const SecureAllocator<T> &, const SecureAllocator<U> &) noexcept {
+  return false;
+}
+
 using secure_string = std::basic_string<char, std::char_traits<char>, SecureAllocator<char>>;
 
 } // namespace smtp


### PR DESCRIPTION
# Description

Fix build errors that occur when using clang-12 to compile instead of gcc. These errors can be found [here](https://c3i.jfrog.io/c3i/misc/logs/pr/19398/11-linux-clang/very-simple-smtps/1.0.0//fc94011d90a2dd58f5b131a39019c88c04047f49-build.txt)

Conan build profile used:
```config
[settings]
arch=x86_64
build_type=Debug
compiler=clang
compiler.libcxx=libstdc++
compiler.version=12
os=Linux
[options]
very-simple-smtps:shared=False
```

To reproduce the issue, copy these settings to one of the build profiles. i.e `debug.profile`

The fix involves defining `==` and `!=` operators for our `SecureAllocator` type.

https://learn.microsoft.com/en-us/cpp/standard-library/allocators?view=msvc-170

Feature/Fix # (issue)

## Dependencies
Any dependencies such as new C++ packages or existing package version updates should be listed here.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
